### PR TITLE
Add Safari playback compatibility

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -5,26 +5,50 @@ use TikScraper\Constants\UserAgents;
 
 class Stream {
     private $buffer_size = 256 * 1024;
+    // Headers to forward back to client, to be filled with response header values from TikTok
+    private array $headers_to_forward = [
+        'Content-Type' => null,
+        'Content-Length' => null,
+        'Content-Range' => null,
+        // Always send this one to explicitly say we accept ranged requests
+        'Accept-Ranges' => 'bytes'
+    ];
 
     public function url($url) {
-        header("Content-Type: video/mp4");
         $ch = curl_init($url);
 
-        $headers = [];
+        $headers_to_send = [];
         if (isset($_SERVER['HTTP_RANGE'])) {
-            $headers[] = 'Range: ' . $_SERVER['HTTP_RANGE'];
+            $headers_to_send[] = 'Range: ' . $_SERVER['HTTP_RANGE'];
+            http_response_code(206);
         }
 
         curl_setopt_array($ch, [
-            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_HTTPHEADER => $headers_to_send,
             CURLOPT_BUFFERSIZE => $this->buffer_size,
             CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_RETURNTRANSFER => false,
+            CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => false,
             CURLOPT_USERAGENT => UserAgents::DEFAULT,
-            CURLOPT_REFERER => "https://www.tiktok.com/discover"
+            CURLOPT_REFERER => "https://www.tiktok.com/discover",
+            CURLOPT_HEADERFUNCTION => function ($curl, $header) {
+                $len = strlen($header);
+                $header = explode(':', $header, 2);
+                $header_key = ucwords(trim($header[0]), '-');
+                if (array_key_exists($header_key, $this->headers_to_forward)) {
+                    $header_value = trim($header[1]);
+                    $this->headers_to_forward[$header_key] = $header_value;
+                }
+                return $len;
+            }
         ]);
-        curl_exec($ch);
+        $response = curl_exec($ch);
+        foreach ($this->headers_to_forward as $header_key => $header_value) {
+            if ($header_value != null) {
+                header($header_key . ': ' . $header_value);
+            }
+        }
+        echo $response;
         curl_close($ch);
     }
 }


### PR DESCRIPTION
Added proper "Ranged" requests support.
Basically, Safari only plays videos from servers that support "Ranged" requests.
I added some headers forwarding to make Safari happy.
Also, for responses where we add "Range" header, we need to send 206 response code, according to the specs.
Tested in Safari, Firefox, Chromium.