### PR TITLE
Fix maxCursor for Trending

### DIFF
--- a/src/Items/Trending.php
+++ b/src/Items/Trending.php
@@ -26,7 +26,7 @@ class Trending extends Base {
 
         $req = $this->sender->sendApi('/api/recommend/item_list', 'm', $query, false, $this->cursor);
         $response = new Feed;
-        $response->fromReq($req, null, $cursor);
+        $response->fromReq($req, null, $this->cursor);
         $this->feed = $response;
         return $this;
     }


### PR DESCRIPTION
For Trending, in the case `$cursor` is empty, `$this->cursor` is updated with `__getTtwid` so it's different from `$cursor` (unlike in other Items where `$this->cursor` is the same as `$cursor`). If we use `$cursor` for `fromReq`, the `maxCursor` will always be `0`. We should use `$this->cursor` instead so that the client can extract `maxCursor` as `ttwid` and later request Trending with that `ttwid`.